### PR TITLE
fix bug: when publish event via stomp, message.payload is the WeEvent object

### DIFF
--- a/weevent-broker/src/main/java/com/webank/weevent/protocol/stomp/BrokerStomp.java
+++ b/weevent-broker/src/main/java/com/webank/weevent/protocol/stomp/BrokerStomp.java
@@ -190,8 +190,6 @@ public class BrokerStomp extends TextWebSocketHandler {
         // send command receipt Id
         String headerReceiptIdStr = getHeadersValue("receipt", msg);
 
-        Map<String, String> extensions = WeEventUtils.getExtend(nativeHeaders);
-
         String groupId = WeEvent.DEFAULT_GROUP_ID;
         Object eventGroupId = nativeHeaders.get(WeEventConstants.EVENT_GROUP_ID);
         if (nativeHeaders.containsKey(WeEventConstants.EVENT_GROUP_ID) && eventGroupId != null) {


### PR DESCRIPTION
when publish event by stomp, message.payload is the event